### PR TITLE
proxy: log errors even if they match the not found pattern

### DIFF
--- a/goproxy.go
+++ b/goproxy.go
@@ -381,6 +381,7 @@ func (g *Goproxy) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		)
 		if err != nil {
 			if regModuleVersionNotFound.MatchString(err.Error()) {
+				g.logError(err)
 				setResponseCacheControlHeader(rw, 60)
 				responseNotFound(rw)
 			} else {
@@ -414,6 +415,7 @@ func (g *Goproxy) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		)
 		if err != nil {
 			if regModuleVersionNotFound.MatchString(err.Error()) {
+				g.logError(err)
 				setResponseCacheControlHeader(rw, 60)
 				responseNotFound(rw)
 			} else {


### PR DESCRIPTION
Hi,

I just spent around 10 minutes trying to find out why a private module was considered not found. I eventually logged the error and got this:

```
2019/09/01 02:28:50 mod latest corp.com/foo/bar@latest: go list -m corp.com/foo/bar: git ls-remote -q origin in /tmp/goproxy932650937/pkg/mod/cache/vcs/4d0351b83b6b91c0f775
74098b7a4b443969bd3633ce32420906f96b480472c3: exit status 128:
        fatal: could not read Username for 'https://corp.com': terminal prompts disabled
If this is a private repository, see https://golang.org/doc/faq#git_https for additional information.
```

Without the log the error is silenced because it matches [this](https://github.com/goproxy/goproxy/blob/master/goproxy.go#L35).

Maybe always logging the error isn't the correct fix here but without this I had no way to know my Git configuration is not working.