### PR TITLE
goproxy: write the status code to the response

### DIFF
--- a/goproxy.go
+++ b/goproxy.go
@@ -339,6 +339,7 @@ func (g *Goproxy) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 			setResponseCacheControlHeader(rw, 60)
 		}
 
+		rw.WriteHeader(sumdbRes.StatusCode)
 		io.Copy(rw, sumdbRes.Body)
 
 		return


### PR DESCRIPTION
Use the one received from the upstream sumdb host