### PR TITLE
feat: add pipe (|) support to built-in GOPROXY support

### DIFF
--- a/goproxy.go
+++ b/goproxy.go
@@ -193,21 +193,31 @@ func (g *Goproxy) load() {
 		g.goBinEnv[parts[0]] = parts[1]
 	}
 
-	var proxies []string
-	for _, proxy := range strings.Split(g.goBinEnv["GOPROXY"], ",") {
-		proxy = strings.TrimSpace(proxy)
-		if proxy == "" {
-			continue
-		}
+	var proxyGroup [][]string
+	for _, proxies := range strings.Split(g.goBinEnv["GOPROXY"], "|") {
+		var cleanProxies []string
+		for _, proxy := range strings.Split(proxies, ",") {
+			proxy = strings.TrimSpace(proxy)
+			if proxy == "" {
+				continue
+			}
 
-		proxies = append(proxies, proxy)
-		if proxy == "direct" || proxy == "off" {
-			break
+			cleanProxies = append(cleanProxies, proxy)
+			if proxy == "direct" || proxy == "off" {
+				break
+			}
+		}
+		if len(cleanProxies) > 0 {
+			proxyGroup = append(proxyGroup, cleanProxies)
 		}
 	}
 
-	if len(proxies) > 0 {
-		g.goBinEnv["GOPROXY"] = strings.Join(proxies, ",")
+	if len(proxyGroup) > 0 {
+		var cleanProxyGroup []string
+		for _, proxies := range proxyGroup {
+			cleanProxyGroup = append(cleanProxyGroup, strings.Join(proxies, ","))
+		}
+		g.goBinEnv["GOPROXY"] = strings.Join(cleanProxyGroup, "|")
 	} else if g.goBinEnv["GOPROXY"] == "" {
 		g.goBinEnv["GOPROXY"] = "https://proxy.golang.org,direct"
 	} else {

--- a/http.go
+++ b/http.go
@@ -1,0 +1,55 @@
+package goproxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+// httpGet gets the content targeted by the url into the dst.
+func httpGet(
+	ctx context.Context,
+	httpClient *http.Client,
+	url string,
+	dst io.Writer,
+) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+
+	res, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		b, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			return err
+		}
+
+		switch res.StatusCode {
+		case http.StatusNotFound, http.StatusGone:
+			return notFoundError(errors.New(string(b)))
+		}
+
+		return fmt.Errorf(
+			"GET %s: %s: %s",
+			redactedURL(req.URL),
+			res.Status,
+			b,
+		)
+	}
+
+	if dst != nil {
+		_, err := io.Copy(dst, res.Body)
+		return err
+	}
+
+	return nil
+}

--- a/sumdb_client_ops.go
+++ b/sumdb_client_ops.go
@@ -1,6 +1,7 @@
 package goproxy
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -65,62 +66,56 @@ func (sco *sumdbClientOps) load() {
 		return
 	}
 
-	for _, proxies := range strings.Split(sco.envGOPROXY, "|") {
-		if sco.endpointURL == nil {
-			for _, proxy := range strings.Split(proxies, ",") {
-				if proxy == "direct" || proxy == "off" {
-					break
-				}
+	for goproxy := sco.envGOPROXY; goproxy != ""; {
+		var (
+			proxy           string
+			fallBackOnError bool
+		)
 
-				var proxyURL *url.URL
-				proxyURL, sco.loadError = parseRawURL(proxy)
-				if sco.loadError != nil {
-					return
-				}
-
-				endpointURL := appendURL(proxyURL, "sumdb", sumdbName)
-				operationURL := appendURL(endpointURL, "/supported")
-
-				var req *http.Request
-				req, sco.loadError = http.NewRequest(
-					http.MethodGet,
-					operationURL.String(),
-					nil,
-				)
-				if sco.loadError != nil {
-					return
-				}
-
-				var res *http.Response
-				res, sco.loadError = sco.httpClient.Do(req)
-				if sco.loadError != nil {
-					return
-				}
-				defer res.Body.Close()
-
-				var b []byte
-				b, sco.loadError = ioutil.ReadAll(res.Body)
-				if sco.loadError != nil {
-					return
-				}
-
-				switch res.StatusCode {
-				case http.StatusOK:
-				case http.StatusNotFound, http.StatusGone:
-					continue
-				default:
-					sco.loadError = fmt.Errorf(
-						"GET %s: %s: %s",
-						redactedURL(operationURL),
-						res.Status,
-						b,
-					)
-					return
-				}
-				sco.endpointURL = endpointURL
-				break
-			}
+		if i := strings.IndexAny(goproxy, ",|"); i >= 0 {
+			proxy = goproxy[:i]
+			fallBackOnError = goproxy[i] == '|'
+			goproxy = goproxy[i+1:]
+		} else {
+			proxy = goproxy
+			goproxy = ""
 		}
+
+		if proxy == "direct" || proxy == "off" {
+			break
+		}
+
+		proxyURL, err := parseRawURL(proxy)
+		if sco.loadError != nil {
+			if fallBackOnError {
+				continue
+			}
+
+			sco.loadError = err
+
+			return
+		}
+
+		endpointURL := appendURL(proxyURL, "sumdb", sumdbName)
+
+		if err := httpGet(
+			context.Background(),
+			sco.httpClient,
+			appendURL(endpointURL, "/supported").String(),
+			nil,
+		); err != nil {
+			if isNotFoundError(err) || fallBackOnError {
+				continue
+			}
+
+			sco.loadError = err
+
+			return
+		}
+
+		sco.endpointURL = endpointURL
+
+		break
 	}
 }
 
@@ -170,10 +165,9 @@ func (sco *sumdbClientOps) ReadConfig(file string) ([]byte, error) {
 		return nil, sco.loadError
 	}
 
-	switch {
-	case file == "key":
+	if file == "key" {
 		return sco.key, nil
-	case strings.HasSuffix(file, "/latest"):
+	} else if strings.HasSuffix(file, "/latest") {
 		return []byte{}, nil // Empty result means empty tree
 	}
 


### PR DESCRIPTION
Support the pipe(|) character in `GOPROXY`. If a proxy URL is followed by a pipe character, the goporxy will try the next proxy in the `GOPROXY` after any error.

see more info: https://golang.org/doc/go1.15#go-command
