### PR TITLE
Add minimal cmd implementation

### DIFF
--- a/cmd/goproxy.go
+++ b/cmd/goproxy.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+
+	"github.com/goproxy/goproxy"
+)
+
+func main() {
+	var listenAddr string
+	flag.StringVar(&listenAddr, "a", "0.0.0.0:8080", "listening address")
+	flag.Parse()
+
+	log.Printf("listening on: %s\n", listenAddr)
+	log.Fatal(http.ListenAndServe(listenAddr, goproxy.New()))
+}


### PR DESCRIPTION
This enables usage of `go install` without having to write any code.

Additionally I suggest to provide binaries with each release.
This makes it easier to setup goproxy on servers since it's not needed to compile the binary or even install Go. This is common practice for other popular Go projects, e.g. [gitea](https://github.com/go-gitea/gitea/releases)