### PR TITLE
Fix serving file when content is not a io.ReadSeeker

### DIFF
--- a/goproxy.go
+++ b/goproxy.go
@@ -620,8 +620,8 @@ func (g *Goproxy) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	setResponseCacheControlHeader(rw, 604800)
-	if content, ok := content.(io.ReadSeeker); ok {
-		http.ServeContent(rw, r, "", modTime, content)
+	if contentRS, ok := content.(io.ReadSeeker); ok {
+		http.ServeContent(rw, r, "", modTime, contentRS)
 	} else {
 		if !modTime.IsZero() {
 			rw.Header().Set(


### PR DESCRIPTION
Remove shadowed var `content` in else block to avoid passing a nil to io.Copy()