### PR TITLE
Change permissions for cached files to 750

### DIFF
--- a/cacher.go
+++ b/cacher.go
@@ -32,7 +32,7 @@ type Cacher interface {
 }
 
 // DirCacher implements the `Cacher` using a directory on the local filesystem.
-// If the directory does not exist, it will be created with 0700 permissions.
+// If the directory does not exist, it will be created with 0750 permissions.
 type DirCacher string
 
 // Get implements the `Cacher`.
@@ -70,7 +70,7 @@ func (dc DirCacher) Set(
 	fileName := filepath.Join(string(dc), filepath.FromSlash(name))
 
 	dir := filepath.Dir(fileName)
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0750); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
First of all: thanks for the library, it's exactly the kind of thing I wanted for my homelab.

This change allows users in the same group as the user running the cacher to access the files.

In my use case, I have a user called `gomod` running the cache, so all files are owned by that user. I have a second machine which backs up my cache periodically, and to practice separation of concerns the backup machine only logs in as a different user, called `backup`.

I'm fine adding `backup` to the `gomod` group, but I don't want `backup` (or the `gomod` user) to have any more permissions than they absolutely need to have.