### PR TITLE
Make Fetch and Fetcher interfaces

### DIFF
--- a/fetch.go
+++ b/fetch.go
@@ -219,7 +219,7 @@ func (f *BuiltinFetch) Do(ctx context.Context) (*FetchResult, error) {
 		return err
 	}, func() error {
 		// go/src/cmd/go/internal/modfetch.errProxyOff
-		return notFoundError("module lookup disabled by GOPROXY=off")
+		return NotFoundError("module lookup disabled by GOPROXY=off")
 	}); err != nil {
 		return nil, err
 	}
@@ -253,7 +253,7 @@ func (f *BuiltinFetch) doProxy(ctx context.Context, proxy string) (*FetchResult,
 		}
 		r.Version, r.Time, err = unmarshalInfo(string(b))
 		if err != nil {
-			return nil, notFoundError(fmt.Sprintf("invalid info response: %v", err))
+			return nil, NotFoundError(fmt.Sprintf("invalid info response: %v", err))
 		}
 	case FetchOpsList:
 		b, err := os.ReadFile(tempFile.Name())
@@ -353,7 +353,7 @@ func (f *BuiltinFetch) doDirect(ctx context.Context) (*FetchResult, error) {
 		msg = strings.TrimPrefix(msg, "go: ")
 		msg = strings.TrimPrefix(msg, "go list -m: ")
 		msg = strings.TrimRight(msg, "\n")
-		return nil, notFoundError(msg)
+		return nil, NotFoundError(msg)
 	}
 
 	r := &FetchResult{F: f}
@@ -411,7 +411,7 @@ func checkAndFormatInfoFile(name string) error {
 	}
 	infoVersion, infoTime, err := unmarshalInfo(string(b))
 	if err != nil {
-		return notFoundError(fmt.Sprintf("invalid info file: %v", err))
+		return NotFoundError(fmt.Sprintf("invalid info file: %v", err))
 	}
 	if info := marshalInfo(infoVersion, infoTime); info != string(b) {
 		return os.WriteFile(name, []byte(info), 0o644)
@@ -437,7 +437,7 @@ func checkModFile(name string) error {
 		return err
 	}
 
-	return notFoundError("invalid mod file: missing module directive")
+	return NotFoundError("invalid mod file: missing module directive")
 }
 
 // verifyModFile uses the SumdbClient to verify the mod file targeted by the
@@ -455,7 +455,7 @@ func verifyModFile(sumdbClient *sumdb.Client, name, modulePath, moduleVersion st
 		return err
 	}
 	if !stringSliceContains(gosumLines, fmt.Sprintf("%s %s/go.mod %s", modulePath, moduleVersion, modHash)) {
-		return notFoundError(fmt.Sprintf("%s@%s: invalid version: untrusted revision %s", modulePath, moduleVersion, moduleVersion))
+		return NotFoundError(fmt.Sprintf("%s@%s: invalid version: untrusted revision %s", modulePath, moduleVersion, moduleVersion))
 	}
 
 	return nil
@@ -465,7 +465,7 @@ func verifyModFile(sumdbClient *sumdb.Client, name, modulePath, moduleVersion st
 // moduleVersion.
 func checkZipFile(name, modulePath, moduleVersion string) error {
 	if _, err := zip.CheckZip(module.Version{Path: modulePath, Version: moduleVersion}, name); err != nil {
-		return notFoundError(fmt.Sprintf("invalid zip file: %v", err))
+		return NotFoundError(fmt.Sprintf("invalid zip file: %v", err))
 	}
 	return nil
 }
@@ -483,7 +483,7 @@ func verifyZipFile(sumdbClient *sumdb.Client, name, modulePath, moduleVersion st
 		return err
 	}
 	if !stringSliceContains(gosumLines, fmt.Sprintf("%s %s %s", modulePath, moduleVersion, zipHash)) {
-		return notFoundError(fmt.Sprintf("%s@%s: invalid version: untrusted revision %s", modulePath, moduleVersion, moduleVersion))
+		return NotFoundError(fmt.Sprintf("%s@%s: invalid version: untrusted revision %s", modulePath, moduleVersion, moduleVersion))
 	}
 
 	return nil

--- a/fetch.go
+++ b/fetch.go
@@ -21,10 +21,93 @@ import (
 	"golang.org/x/mod/zip"
 )
 
-// fetch is a module fetch. All of its fields are populated only by [newFetch].
-type fetch struct {
+// Fetcher is an interface for performing fetch operations from another source such as
+// an upstream proxy, a private VCS, or direct via Go tools
+// The Builtin implementation faithfully follows the GOPROXY protocol
+
+type Fetch interface {
+	Name() string
+	ContentType() string
+	Do(ctx context.Context) (*FetchResult, error)
+	Ops() FetchOps
+}
+type Fetcher interface {
+	NewFetch(*Goproxy, string, string) (Fetch, error)
+}
+
+// FetchOps is the operation of the [Fetch].
+type FetchOps uint8
+
+// The BuiltinFetch operations.
+const (
+	FetchOpsInvalid FetchOps = iota
+	FetchOpsResolve
+	FetchOpsList
+	FetchOpsDownloadInfo
+	FetchOpsDownloadMod
+	FetchOpsDownloadZip
+)
+
+// String implements the [fmt.Stringer].
+func (fo FetchOps) String() string {
+	switch fo {
+	case FetchOpsResolve:
+		return "resolve"
+	case FetchOpsList:
+		return "list"
+	case FetchOpsDownloadInfo:
+		return "download info"
+	case FetchOpsDownloadMod:
+		return "download mod"
+	case FetchOpsDownloadZip:
+		return "download zip"
+	}
+
+	return "invalid"
+}
+
+// FetchResult is a unified result for the [Fetch].
+type FetchResult struct {
+	F Fetch
+
+	Version  string
+	Time     time.Time
+	Versions []string
+	Info     string
+	GoMod    string
+	Zip      string
+}
+
+// Open opens the content of the fr.
+func (fr *FetchResult) Open() (io.ReadSeekCloser, error) {
+	switch fr.F.Ops() {
+	case FetchOpsResolve:
+		content := strings.NewReader(marshalInfo(fr.Version, fr.Time))
+		return struct {
+			io.ReadCloser
+			io.Seeker
+		}{io.NopCloser(content), content}, nil
+	case FetchOpsList:
+		content := strings.NewReader(strings.Join(fr.Versions, "\n"))
+		return struct {
+			io.ReadCloser
+			io.Seeker
+		}{io.NopCloser(content), content}, nil
+	case FetchOpsDownloadInfo:
+		return os.Open(fr.Info)
+	case FetchOpsDownloadMod:
+		return os.Open(fr.GoMod)
+	case FetchOpsDownloadZip:
+		return os.Open(fr.Zip)
+	}
+
+	return nil, errors.New("invalid BuiltinFetch operation")
+}
+
+// BuiltinFetch is a module BuiltinFetch. All its fields are populated only by the [NewFetch].
+type BuiltinFetch struct {
 	g                *Goproxy
-	ops              fetchOps
+	ops              FetchOps
 	name             string
 	tempDir          string
 	modulePath       string
@@ -34,9 +117,11 @@ type fetch struct {
 	contentType      string
 }
 
-// newFetch parses the name and returns a new [fetch].
-func newFetch(g *Goproxy, name, tempDir string) (*fetch, error) {
-	f := &fetch{
+type BuiltinFetcher string
+
+// newFetch returns a new instance of the [Fetch].
+func (fetcher BuiltinFetcher) NewFetch(g *Goproxy, name, tempDir string) (Fetch, error) {
+	f := &BuiltinFetch{
 		g:       g,
 		name:    name,
 		tempDir: tempDir,
@@ -44,12 +129,12 @@ func newFetch(g *Goproxy, name, tempDir string) (*fetch, error) {
 	var escapedModulePath string
 	if strings.HasSuffix(name, "/@latest") {
 		escapedModulePath = strings.TrimSuffix(name, "/@latest")
-		f.ops = fetchOpsResolve
+		f.ops = FetchOpsResolve
 		f.moduleVersion = "latest"
 		f.contentType = "application/json; charset=utf-8"
 	} else if strings.HasSuffix(name, "/@v/list") {
 		escapedModulePath = strings.TrimSuffix(name, "/@v/list")
-		f.ops = fetchOpsList
+		f.ops = FetchOpsList
 		f.moduleVersion = "latest"
 		f.contentType = "text/plain; charset=utf-8"
 	} else {
@@ -66,13 +151,13 @@ func newFetch(g *Goproxy, name, tempDir string) (*fetch, error) {
 		escapedModuleVersion := strings.TrimSuffix(base, ext)
 		switch ext {
 		case ".info":
-			f.ops = fetchOpsDownloadInfo
+			f.ops = FetchOpsDownloadInfo
 			f.contentType = "application/json; charset=utf-8"
 		case ".mod":
-			f.ops = fetchOpsDownloadMod
+			f.ops = FetchOpsDownloadMod
 			f.contentType = "text/plain; charset=utf-8"
 		case ".zip":
-			f.ops = fetchOpsDownloadZip
+			f.ops = FetchOpsDownloadZip
 			f.contentType = "application/zip"
 		case "":
 			return nil, fmt.Errorf("no file extension in filename %q", escapedModuleVersion)
@@ -89,8 +174,8 @@ func newFetch(g *Goproxy, name, tempDir string) (*fetch, error) {
 		if f.moduleVersion == "latest" {
 			return nil, errors.New("invalid version")
 		} else if !semver.IsValid(f.moduleVersion) {
-			if f.ops == fetchOpsDownloadInfo {
-				f.ops = fetchOpsResolve
+			if f.ops == FetchOpsDownloadInfo {
+				f.ops = FetchOpsResolve
 			} else {
 				return nil, errors.New("unrecognized version")
 			}
@@ -106,12 +191,24 @@ func newFetch(g *Goproxy, name, tempDir string) (*fetch, error) {
 	return f, nil
 }
 
-// do executes the f.
-func (f *fetch) do(ctx context.Context) (*fetchResult, error) {
+func (f *BuiltinFetch) Name() string {
+	return f.name
+}
+
+func (f *BuiltinFetch) ContentType() string {
+	return f.contentType
+}
+
+func (f *BuiltinFetch) Ops() FetchOps {
+	return f.ops
+}
+
+// Do executes the f.
+func (f *BuiltinFetch) Do(ctx context.Context) (*FetchResult, error) {
 	if globsMatchPath(f.g.envGONOPROXY, f.modulePath) {
 		return f.doDirect(ctx)
 	}
-	var r *fetchResult
+	var r *FetchResult
 	if err := walkGOPROXY(f.g.envGOPROXY, func(proxy string) error {
 		var err error
 		r, err = f.doProxy(ctx, proxy)
@@ -130,7 +227,7 @@ func (f *fetch) do(ctx context.Context) (*fetchResult, error) {
 }
 
 // doProxy executes the f via the proxy.
-func (f *fetch) doProxy(ctx context.Context, proxy string) (*fetchResult, error) {
+func (f *BuiltinFetch) doProxy(ctx context.Context, proxy string) (*FetchResult, error) {
 	proxyURL, err := parseRawURL(proxy)
 	if err != nil {
 		return nil, err
@@ -140,16 +237,16 @@ func (f *fetch) doProxy(ctx context.Context, proxy string) (*fetchResult, error)
 	if err != nil {
 		return nil, err
 	}
-	if err := httpGet(ctx, f.g.httpClient, appendURL(proxyURL, f.name).String(), tempFile); err != nil {
+	if err := httpGet(ctx, f.g.HttpClient, appendURL(proxyURL, f.name).String(), tempFile); err != nil {
 		return nil, err
 	}
 	if err := tempFile.Close(); err != nil {
 		return nil, err
 	}
 
-	r := &fetchResult{f: f}
+	r := &FetchResult{F: f}
 	switch f.ops {
-	case fetchOpsResolve:
+	case FetchOpsResolve:
 		b, err := os.ReadFile(tempFile.Name())
 		if err != nil {
 			return nil, err
@@ -158,7 +255,7 @@ func (f *fetch) doProxy(ctx context.Context, proxy string) (*fetchResult, error)
 		if err != nil {
 			return nil, notFoundError(fmt.Sprintf("invalid info response: %v", err))
 		}
-	case fetchOpsList:
+	case FetchOpsList:
 		b, err := os.ReadFile(tempFile.Name())
 		if err != nil {
 			return nil, err
@@ -177,27 +274,27 @@ func (f *fetch) doProxy(ctx context.Context, proxy string) (*fetchResult, error)
 		sort.Slice(r.Versions, func(i, j int) bool {
 			return semver.Compare(r.Versions[i], r.Versions[j]) < 0
 		})
-	case fetchOpsDownloadInfo:
+	case FetchOpsDownloadInfo:
 		if err := checkAndFormatInfoFile(tempFile.Name()); err != nil {
 			return nil, err
 		}
 		r.Info = tempFile.Name()
-	case fetchOpsDownloadMod:
+	case FetchOpsDownloadMod:
 		if err := checkModFile(tempFile.Name()); err != nil {
 			return nil, err
 		}
 		if f.requiredToVerify {
-			if err := verifyModFile(f.g.sumdbClient, tempFile.Name(), f.modulePath, f.moduleVersion); err != nil {
+			if err := verifyModFile(f.g.SumdbClient, tempFile.Name(), f.modulePath, f.moduleVersion); err != nil {
 				return nil, err
 			}
 		}
 		r.GoMod = tempFile.Name()
-	case fetchOpsDownloadZip:
+	case FetchOpsDownloadZip:
 		if err := checkZipFile(tempFile.Name(), f.modulePath, f.moduleVersion); err != nil {
 			return nil, err
 		}
 		if f.requiredToVerify {
-			if err := verifyZipFile(f.g.sumdbClient, tempFile.Name(), f.modulePath, f.moduleVersion); err != nil {
+			if err := verifyZipFile(f.g.SumdbClient, tempFile.Name(), f.modulePath, f.moduleVersion); err != nil {
 				return nil, err
 			}
 		}
@@ -207,7 +304,7 @@ func (f *fetch) doProxy(ctx context.Context, proxy string) (*fetchResult, error)
 }
 
 // doDirect executes the f directly using the local go command.
-func (f *fetch) doDirect(ctx context.Context) (*fetchResult, error) {
+func (f *BuiltinFetch) doDirect(ctx context.Context) (*FetchResult, error) {
 	if f.g.directFetchWorkerPool != nil {
 		f.g.directFetchWorkerPool <- struct{}{}
 		defer func() { <-f.g.directFetchWorkerPool }()
@@ -215,11 +312,11 @@ func (f *fetch) doDirect(ctx context.Context) (*fetchResult, error) {
 
 	var args []string
 	switch f.ops {
-	case fetchOpsResolve:
+	case FetchOpsResolve:
 		args = []string{"list", "-json", "-m", f.modAtVer}
-	case fetchOpsList:
+	case FetchOpsList:
 		args = []string{"list", "-json", "-m", "-versions", f.modAtVer}
-	case fetchOpsDownloadInfo, fetchOpsDownloadMod, fetchOpsDownloadZip:
+	case FetchOpsDownloadInfo, FetchOpsDownloadMod, FetchOpsDownloadZip:
 		args = []string{"mod", "download", "-json", f.modAtVer}
 	}
 
@@ -259,96 +356,30 @@ func (f *fetch) doDirect(ctx context.Context) (*fetchResult, error) {
 		return nil, notFoundError(msg)
 	}
 
-	r := &fetchResult{f: f}
+	r := &FetchResult{F: f}
 	if err := json.Unmarshal(stdout, r); err != nil {
 		return nil, err
 	}
 	switch f.ops {
-	case fetchOpsList:
+	case FetchOpsList:
 		sort.Slice(r.Versions, func(i, j int) bool {
 			return semver.Compare(r.Versions[i], r.Versions[j]) < 0
 		})
-	case fetchOpsDownloadInfo, fetchOpsDownloadMod, fetchOpsDownloadZip:
+	case FetchOpsDownloadInfo, FetchOpsDownloadMod, FetchOpsDownloadZip:
 		if err := checkAndFormatInfoFile(r.Info); err != nil {
 			return nil, err
 		}
 		if f.requiredToVerify {
-			if err := verifyModFile(f.g.sumdbClient, r.GoMod, f.modulePath, f.moduleVersion); err != nil {
+			if err := verifyModFile(f.g.SumdbClient, r.GoMod, f.modulePath, f.moduleVersion); err != nil {
 				return nil, err
 			}
-			if err := verifyZipFile(f.g.sumdbClient, r.Zip, f.modulePath, f.moduleVersion); err != nil {
+
+			if err := verifyZipFile(f.g.SumdbClient, r.Zip, f.modulePath, f.moduleVersion); err != nil {
 				return nil, err
 			}
 		}
 	}
 	return r, nil
-}
-
-// fetchOps is the operation of [fetch].
-type fetchOps uint8
-
-// The fetch operations.
-const (
-	fetchOpsInvalid fetchOps = iota
-	fetchOpsResolve
-	fetchOpsList
-	fetchOpsDownloadInfo
-	fetchOpsDownloadMod
-	fetchOpsDownloadZip
-)
-
-// String implements [fmt.Stringer].
-func (fo fetchOps) String() string {
-	switch fo {
-	case fetchOpsResolve:
-		return "resolve"
-	case fetchOpsList:
-		return "list"
-	case fetchOpsDownloadInfo:
-		return "download info"
-	case fetchOpsDownloadMod:
-		return "download mod"
-	case fetchOpsDownloadZip:
-		return "download zip"
-	}
-	return "invalid"
-}
-
-// fetchResult is a unified result for [fetch].
-type fetchResult struct {
-	f *fetch
-
-	Version  string
-	Time     time.Time
-	Versions []string
-	Info     string
-	GoMod    string
-	Zip      string
-}
-
-// Open opens the content of the fr.
-func (fr *fetchResult) Open() (io.ReadSeekCloser, error) {
-	switch fr.f.ops {
-	case fetchOpsResolve:
-		content := strings.NewReader(marshalInfo(fr.Version, fr.Time))
-		return struct {
-			io.ReadCloser
-			io.Seeker
-		}{io.NopCloser(content), content}, nil
-	case fetchOpsList:
-		content := strings.NewReader(strings.Join(fr.Versions, "\n"))
-		return struct {
-			io.ReadCloser
-			io.Seeker
-		}{io.NopCloser(content), content}, nil
-	case fetchOpsDownloadInfo:
-		return os.Open(fr.Info)
-	case fetchOpsDownloadMod:
-		return os.Open(fr.GoMod)
-	case fetchOpsDownloadZip:
-		return os.Open(fr.Zip)
-	}
-	return nil, errors.New("invalid fetch operation")
 }
 
 // marshalInfo marshals the version and t as info.
@@ -409,7 +440,7 @@ func checkModFile(name string) error {
 	return notFoundError("invalid mod file: missing module directive")
 }
 
-// verifyModFile uses the sumdbClient to verify the mod file targeted by the
+// verifyModFile uses the SumdbClient to verify the mod file targeted by the
 // name with the modulePath and moduleVersion.
 func verifyModFile(sumdbClient *sumdb.Client, name, modulePath, moduleVersion string) error {
 	gosumLines, err := sumdbClient.Lookup(modulePath, moduleVersion+"/go.mod")
@@ -439,7 +470,7 @@ func checkZipFile(name, modulePath, moduleVersion string) error {
 	return nil
 }
 
-// verifyZipFile uses the sumdbClient to verify the zip file targeted by the
+// verifyZipFile uses the SumdbClient to verify the zip file targeted by the
 // name with the modulePath and moduleVersion.
 func verifyZipFile(sumdbClient *sumdb.Client, name, modulePath, moduleVersion string) error {
 	gosumLines, err := sumdbClient.Lookup(modulePath, moduleVersion)

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -266,7 +266,7 @@ func TestFetchDo(t *testing.T) {
 				return nil
 			},
 			name:      "example.com/@latest",
-			wantError: notFoundError(fmt.Sprintf("module example.com: reading %s/example.com/@v/list: 404 Not Found\n\tserver response: not found", proxyServer.URL)),
+			wantError: NotFoundError(fmt.Sprintf("module example.com: reading %s/example.com/@v/list: 404 Not Found\n\tserver response: not found", proxyServer.URL)),
 		},
 		{
 			n:            3,
@@ -281,7 +281,7 @@ func TestFetchDo(t *testing.T) {
 				return nil
 			},
 			name:      "example.com/@latest",
-			wantError: notFoundError("example.com@latest: module lookup disabled by GOPROXY=off"),
+			wantError: NotFoundError("example.com@latest: module lookup disabled by GOPROXY=off"),
 		},
 		{
 			n:            4,
@@ -291,7 +291,7 @@ func TestFetchDo(t *testing.T) {
 				"GOSUMDB=off",
 			},
 			name:      "example.com/@latest",
-			wantError: notFoundError("module lookup disabled by GOPROXY=off"),
+			wantError: NotFoundError("module lookup disabled by GOPROXY=off"),
 		},
 	} {
 		setProxyHandler(tt.proxyHandler)
@@ -409,7 +409,7 @@ func TestFetchDoProxy(t *testing.T) {
 			name:      "example.com/@latest",
 			tempDir:   t.TempDir(),
 			proxy:     proxyServer.URL,
-			wantError: notFoundError("invalid info response: zero time"),
+			wantError: NotFoundError("invalid info response: zero time"),
 		},
 		{
 			n: 3,
@@ -445,7 +445,7 @@ invalid
 			name:      "example.com/@v/v1.0.0.info",
 			tempDir:   t.TempDir(),
 			proxy:     proxyServer.URL,
-			wantError: notFoundError("invalid info file: zero time"),
+			wantError: NotFoundError("invalid info file: zero time"),
 		},
 		{
 			n: 6,
@@ -485,7 +485,7 @@ invalid
 			name:      "example.com/@v/v1.1.0.mod",
 			tempDir:   t.TempDir(),
 			proxy:     proxyServer.URL,
-			wantError: notFoundError("example.com@v1.1.0: invalid version: untrusted revision v1.1.0"),
+			wantError: NotFoundError("example.com@v1.1.0: invalid version: untrusted revision v1.1.0"),
 		},
 		{
 			n: 9,
@@ -495,7 +495,7 @@ invalid
 			name:      "example.com/@v/v1.0.0.mod",
 			tempDir:   t.TempDir(),
 			proxy:     proxyServer.URL,
-			wantError: notFoundError("invalid mod file: missing module directive"),
+			wantError: NotFoundError("invalid mod file: missing module directive"),
 		},
 		{
 			n: 10,
@@ -558,7 +558,7 @@ invalid
 			name:      "example.com/@v/v1.3.0.zip",
 			tempDir:   t.TempDir(),
 			proxy:     proxyServer.URL,
-			wantError: notFoundError("example.com@v1.3.0: invalid version: untrusted revision v1.3.0"),
+			wantError: NotFoundError("example.com@v1.3.0: invalid version: untrusted revision v1.3.0"),
 		},
 		{
 			n: 13,
@@ -568,7 +568,7 @@ invalid
 			name:      "example.com/@v/v1.0.0.zip",
 			tempDir:   t.TempDir(),
 			proxy:     proxyServer.URL,
-			wantError: notFoundError("invalid zip file: zip: not a valid zip file"),
+			wantError: NotFoundError("invalid zip file: zip: not a valid zip file"),
 		},
 		{
 			n:            14,
@@ -768,7 +768,7 @@ func TestFetchDoDirect(t *testing.T) {
 		{
 			n:         6,
 			name:      "example.com/@v/v1.1.0.info",
-			wantError: notFoundError("zip for example.com@v1.1.0 has unexpected file example.com@v1.0.0/go.mod"),
+			wantError: NotFoundError("zip for example.com@v1.1.0 has unexpected file example.com@v1.0.0/go.mod"),
 		},
 		{
 			n:          7,
@@ -818,7 +818,7 @@ func TestFetchDoDirect(t *testing.T) {
 				return []byte(gosum), nil
 			})),
 			name:      "example.com/@v/v1.0.0.info",
-			wantError: notFoundError("example.com@v1.0.0: invalid version: untrusted revision v1.0.0"),
+			wantError: NotFoundError("example.com@v1.0.0: invalid version: untrusted revision v1.0.0"),
 		},
 		{
 			n: 13,
@@ -828,7 +828,7 @@ func TestFetchDoDirect(t *testing.T) {
 				return []byte(gosum), nil
 			})),
 			name:      "example.com/@v/v1.0.0.info",
-			wantError: notFoundError("example.com@v1.0.0: invalid version: untrusted revision v1.0.0"),
+			wantError: NotFoundError("example.com@v1.0.0: invalid version: untrusted revision v1.0.0"),
 		},
 	} {
 		ctx := context.Background()
@@ -1074,7 +1074,7 @@ func TestCheckAndFormatInfoFile(t *testing.T) {
 		{
 			n:         1,
 			info:      "{}",
-			wantError: notFoundError("invalid info file: empty version"),
+			wantError: NotFoundError("invalid info file: empty version"),
 		},
 		{
 			n:        2,
@@ -1125,7 +1125,7 @@ func TestCheckModFile(t *testing.T) {
 		mod       string
 		wantError error
 	}{
-		{1, "foobar", notFoundError("invalid mod file: missing module directive")},
+		{1, "foobar", NotFoundError("invalid mod file: missing module directive")},
 		{2, "module", nil},
 		{3, "// foobar\nmodule foobar", nil},
 		{4, "", fs.ErrNotExist},

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -24,7 +24,7 @@ func TestNewFetch(t *testing.T) {
 		n                    int
 		env                  []string
 		name                 string
-		wantOps              fetchOps
+		wantOps              FetchOps
 		wantModulePath       string
 		wantModuleVersion    string
 		wantModAtVer         string
@@ -35,7 +35,7 @@ func TestNewFetch(t *testing.T) {
 		{
 			n:                    1,
 			name:                 "example.com/@latest",
-			wantOps:              fetchOpsResolve,
+			wantOps:              FetchOpsResolve,
 			wantModulePath:       "example.com",
 			wantModuleVersion:    "latest",
 			wantModAtVer:         "example.com@latest",
@@ -46,7 +46,7 @@ func TestNewFetch(t *testing.T) {
 			n:                    2,
 			env:                  []string{"GOSUMDB=off"},
 			name:                 "example.com/@latest",
-			wantOps:              fetchOpsResolve,
+			wantOps:              FetchOpsResolve,
 			wantModulePath:       "example.com",
 			wantModuleVersion:    "latest",
 			wantModAtVer:         "example.com@latest",
@@ -57,7 +57,7 @@ func TestNewFetch(t *testing.T) {
 			n:                    3,
 			env:                  []string{"GONOSUMDB=example.com"},
 			name:                 "example.com/@latest",
-			wantOps:              fetchOpsResolve,
+			wantOps:              FetchOpsResolve,
 			wantModulePath:       "example.com",
 			wantModuleVersion:    "latest",
 			wantModAtVer:         "example.com@latest",
@@ -68,7 +68,7 @@ func TestNewFetch(t *testing.T) {
 			n:                    4,
 			env:                  []string{"GOPRIVATE=example.com"},
 			name:                 "example.com/@latest",
-			wantOps:              fetchOpsResolve,
+			wantOps:              FetchOpsResolve,
 			wantModulePath:       "example.com",
 			wantModuleVersion:    "latest",
 			wantModAtVer:         "example.com@latest",
@@ -78,7 +78,7 @@ func TestNewFetch(t *testing.T) {
 		{
 			n:                    5,
 			name:                 "example.com/@v/list",
-			wantOps:              fetchOpsList,
+			wantOps:              FetchOpsList,
 			wantModulePath:       "example.com",
 			wantModuleVersion:    "latest",
 			wantModAtVer:         "example.com@latest",
@@ -88,7 +88,7 @@ func TestNewFetch(t *testing.T) {
 		{
 			n:                    6,
 			name:                 "example.com/@v/v1.0.0.info",
-			wantOps:              fetchOpsDownloadInfo,
+			wantOps:              FetchOpsDownloadInfo,
 			wantModulePath:       "example.com",
 			wantModuleVersion:    "v1.0.0",
 			wantModAtVer:         "example.com@v1.0.0",
@@ -98,7 +98,7 @@ func TestNewFetch(t *testing.T) {
 		{
 			n:                    7,
 			name:                 "example.com/@v/v1.0.0.mod",
-			wantOps:              fetchOpsDownloadMod,
+			wantOps:              FetchOpsDownloadMod,
 			wantModulePath:       "example.com",
 			wantModuleVersion:    "v1.0.0",
 			wantModAtVer:         "example.com@v1.0.0",
@@ -108,7 +108,7 @@ func TestNewFetch(t *testing.T) {
 		{
 			n:                    8,
 			name:                 "example.com/@v/v1.0.0.zip",
-			wantOps:              fetchOpsDownloadZip,
+			wantOps:              FetchOpsDownloadZip,
 			wantModulePath:       "example.com",
 			wantModuleVersion:    "v1.0.0",
 			wantModAtVer:         "example.com@v1.0.0",
@@ -128,7 +128,7 @@ func TestNewFetch(t *testing.T) {
 		{
 			n:                    11,
 			name:                 "example.com/@v/master.info",
-			wantOps:              fetchOpsResolve,
+			wantOps:              FetchOpsResolve,
 			wantModulePath:       "example.com",
 			wantModuleVersion:    "master",
 			wantModAtVer:         "example.com@master",
@@ -163,7 +163,7 @@ func TestNewFetch(t *testing.T) {
 		{
 			n:                    17,
 			name:                 "example.com/!foobar/@v/!v1.0.0.info",
-			wantOps:              fetchOpsResolve,
+			wantOps:              FetchOpsResolve,
 			wantModulePath:       "example.com/Foobar",
 			wantModuleVersion:    "V1.0.0",
 			wantModAtVer:         "example.com/Foobar@V1.0.0",
@@ -914,16 +914,16 @@ func TestFetchDoDirect(t *testing.T) {
 func TestFetchOpsString(t *testing.T) {
 	for _, tt := range []struct {
 		n            int
-		fo           fetchOps
+		fo           FetchOps
 		wantFetchOps string
 	}{
-		{1, fetchOpsResolve, "resolve"},
-		{2, fetchOpsList, "list"},
-		{3, fetchOpsDownloadInfo, "download info"},
-		{4, fetchOpsDownloadMod, "download mod"},
-		{5, fetchOpsDownloadZip, "download zip"},
-		{6, fetchOpsInvalid, "invalid"},
-		{7, fetchOps(255), "invalid"},
+		{1, FetchOpsResolve, "resolve"},
+		{2, FetchOpsList, "list"},
+		{3, FetchOpsDownloadInfo, "download info"},
+		{4, FetchOpsDownloadMod, "download mod"},
+		{5, FetchOpsDownloadZip, "download zip"},
+		{6, FetchOpsInvalid, "invalid"},
+		{7, FetchOps(255), "invalid"},
 	} {
 		if got, want := tt.fo.String(), tt.wantFetchOps; got != want {
 			t.Errorf("test(%d): got %q, want %q", tt.n, got, want)
@@ -934,42 +934,42 @@ func TestFetchOpsString(t *testing.T) {
 func TestFetchResultOpen(t *testing.T) {
 	for _, tt := range []struct {
 		n                int
-		fr               *fetchResult
-		setupFetchResult func(fr *fetchResult) error
+		fr               *FetchResult
+		setupFetchResult func(fr *FetchResult) error
 		wantContent      string
 		wantError        error
 	}{
 		{
 			n:           1,
-			fr:          &fetchResult{f: &fetch{ops: fetchOpsResolve}, Version: "v1.0.0", Time: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)},
+			fr:          &FetchResult{f: &Fetch{ops: FetchOpsResolve}, Version: "v1.0.0", Time: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)},
 			wantContent: `{"Version":"v1.0.0","Time":"2000-01-01T00:00:00Z"}`,
 		},
 		{
 			n:           2,
-			fr:          &fetchResult{f: &fetch{ops: fetchOpsList}, Versions: []string{"v1.0.0", "v1.1.0"}},
+			fr:          &FetchResult{f: &Fetch{ops: FetchOpsList}, Versions: []string{"v1.0.0", "v1.1.0"}},
 			wantContent: "v1.0.0\nv1.1.0",
 		},
 		{
 			n:                3,
-			fr:               &fetchResult{f: &fetch{ops: fetchOpsDownloadInfo}, Info: filepath.Join(t.TempDir(), "info")},
-			setupFetchResult: func(fr *fetchResult) error { return os.WriteFile(fr.Info, []byte("info"), 0o644) },
+			fr:               &FetchResult{f: &Fetch{ops: FetchOpsDownloadInfo}, Info: filepath.Join(t.TempDir(), "info")},
+			setupFetchResult: func(fr *FetchResult) error { return os.WriteFile(fr.Info, []byte("info"), 0o644) },
 			wantContent:      "info",
 		},
 		{
 			n:                4,
-			fr:               &fetchResult{f: &fetch{ops: fetchOpsDownloadMod}, GoMod: filepath.Join(t.TempDir(), "mod")},
-			setupFetchResult: func(fr *fetchResult) error { return os.WriteFile(fr.GoMod, []byte("mod"), 0o644) },
+			fr:               &FetchResult{f: &Fetch{ops: FetchOpsDownloadMod}, GoMod: filepath.Join(t.TempDir(), "mod")},
+			setupFetchResult: func(fr *FetchResult) error { return os.WriteFile(fr.GoMod, []byte("mod"), 0o644) },
 			wantContent:      "mod",
 		},
 		{
 			n:                5,
-			fr:               &fetchResult{f: &fetch{ops: fetchOpsDownloadZip}, Zip: filepath.Join(t.TempDir(), "zip")},
-			setupFetchResult: func(fr *fetchResult) error { return os.WriteFile(fr.Zip, []byte("zip"), 0o644) },
+			fr:               &FetchResult{f: &Fetch{ops: FetchOpsDownloadZip}, Zip: filepath.Join(t.TempDir(), "zip")},
+			setupFetchResult: func(fr *FetchResult) error { return os.WriteFile(fr.Zip, []byte("zip"), 0o644) },
 			wantContent:      "zip",
 		},
 		{
 			n:         6,
-			fr:        &fetchResult{f: &fetch{ops: fetchOpsInvalid}},
+			fr:        &FetchResult{f: &Fetch{ops: FetchOpsInvalid}},
 			wantError: errors.New("invalid fetch operation"),
 		},
 	} {
@@ -1211,7 +1211,7 @@ func TestVerifyModFile(t *testing.T) {
 			modFile:       modFile,
 			modulePath:    "example.com",
 			moduleVersion: "v1.1.0",
-			wantError:     notFoundError("example.com@v1.1.0/go.mod: bad upstream"),
+			wantError:     NotFoundError("example.com@v1.1.0/go.mod: bad upstream"),
 		},
 		{
 			n:             3,
@@ -1225,10 +1225,10 @@ func TestVerifyModFile(t *testing.T) {
 			modFile:       modFile2,
 			modulePath:    "example.com",
 			moduleVersion: "v1.0.0",
-			wantError:     notFoundError("example.com@v1.0.0: invalid version: untrusted revision v1.0.0"),
+			wantError:     NotFoundError("example.com@v1.0.0: invalid version: untrusted revision v1.0.0"),
 		},
 	} {
-		err := verifyModFile(g.sumdbClient, tt.modFile, tt.modulePath, tt.moduleVersion)
+		err := verifyModFile(g.SumdbClient, tt.modFile, tt.modulePath, tt.moduleVersion)
 		if tt.wantError != nil {
 			if err == nil {
 				t.Fatalf("test(%d): expected error", tt.n)
@@ -1267,7 +1267,7 @@ func TestCheckZipFile(t *testing.T) {
 			zipFile:       zipFile,
 			modulePath:    "example.com",
 			moduleVersion: "v1.1.0",
-			wantError:     notFoundError(`invalid zip file: example.com@v1.0.0/go.mod: path does not have prefix "example.com@v1.1.0/"`),
+			wantError:     NotFoundError(`invalid zip file: example.com@v1.0.0/go.mod: path does not have prefix "example.com@v1.1.0/"`),
 		},
 		{
 			n:             3,
@@ -1354,7 +1354,7 @@ func TestVerifyZipFile(t *testing.T) {
 			zipFile:       zipFile,
 			modulePath:    "example.com",
 			moduleVersion: "v1.1.0",
-			wantError:     notFoundError("example.com@v1.1.0: bad upstream"),
+			wantError:     NotFoundError("example.com@v1.1.0: bad upstream"),
 		},
 		{
 			n:             3,
@@ -1368,10 +1368,10 @@ func TestVerifyZipFile(t *testing.T) {
 			zipFile:       zipFile2,
 			modulePath:    "example.com",
 			moduleVersion: "v1.0.0",
-			wantError:     notFoundError("example.com@v1.0.0: invalid version: untrusted revision v1.0.0"),
+			wantError:     NotFoundError("example.com@v1.0.0: invalid version: untrusted revision v1.0.0"),
 		},
 	} {
-		err := verifyZipFile(g.sumdbClient, tt.zipFile, tt.modulePath, tt.moduleVersion)
+		err := verifyZipFile(g.SumdbClient, tt.zipFile, tt.modulePath, tt.moduleVersion)
 		if tt.wantError != nil {
 			if err == nil {
 				t.Fatalf("test(%d): expected error", tt.n)

--- a/goproxy_test.go
+++ b/goproxy_test.go
@@ -515,7 +515,7 @@ func TestGoproxyServeFetchDownload(t *testing.T) {
 			ErrorLogger: log.New(io.Discard, "", 0),
 		}
 		g.init()
-		f, err := newFetch(g, tt.name, t.TempDir())
+		f, err := g.Fetcher.NewFetch(g, tt.name, t.TempDir())
 		if err != nil {
 			t.Fatalf("test(%d): unexpected error %q", tt.n, err)
 		}

--- a/http.go
+++ b/http.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	// errNotFound indicates something was not found.
-	errNotFound = notFoundError("not found")
+	errNotFound = NotFoundError("not found")
 
 	// errBadUpstream indicates an upstream is in a bad state.
 	errBadUpstream = errors.New("bad upstream")
@@ -26,16 +26,16 @@ var (
 	errFetchTimedOut = errors.New("fetch timed out")
 )
 
-// notFoundError is an error indicating that something was not found.
-type notFoundError string
+// NotFoundError is an error indicating that something was not found.
+type NotFoundError string
 
 // Error implements [error].
-func (nfe notFoundError) Error() string {
+func (nfe NotFoundError) Error() string {
 	return string(nfe)
 }
 
 // Is reports whether the target matches [errNotFound] or [fs.ErrNotExist].
-func (notFoundError) Is(target error) bool {
+func (NotFoundError) Is(target error) bool {
 	switch target {
 	case errNotFound, fs.ErrNotExist:
 		return true
@@ -85,7 +85,7 @@ func httpGet(ctx context.Context, client *http.Client, url string, dst io.Writer
 		case http.StatusBadRequest,
 			http.StatusNotFound,
 			http.StatusGone:
-			return notFoundError(respBody)
+			return NotFoundError(respBody)
 		case http.StatusTooManyRequests,
 			http.StatusInternalServerError,
 			http.StatusBadGateway,

--- a/http.go
+++ b/http.go
@@ -22,7 +22,7 @@ var (
 	// errBadUpstream indicates an upstream is in a bad state.
 	errBadUpstream = errors.New("bad upstream")
 
-	// errFetchTimedOut indicates a fetch operation has timed out.
+	// errFetchTimedOut means a fetch operation has timed out.
 	errFetchTimedOut = errors.New("fetch timed out")
 )
 

--- a/http_test.go
+++ b/http_test.go
@@ -19,13 +19,13 @@ import (
 func TestNotFoundError(t *testing.T) {
 	for _, tt := range []struct {
 		n         int
-		nfe       notFoundError
+		nfe       NotFoundError
 		wantError error
 	}{
-		{1, notFoundError(""), errors.New("")},
-		{2, notFoundError("foobar"), errors.New("foobar")},
-		{3, notFoundError("foobar"), fs.ErrNotExist},
-		{3, notFoundError("foobar"), errNotFound},
+		{1, NotFoundError(""), errors.New("")},
+		{2, NotFoundError("foobar"), errors.New("foobar")},
+		{3, NotFoundError("foobar"), fs.ErrNotExist},
+		{3, NotFoundError("foobar"), errNotFound},
 		{3, errNotFound, fs.ErrNotExist},
 	} {
 		if got, want := tt.nfe, tt.wantError; !errors.Is(got, want) && got.Error() != want.Error() {
@@ -33,7 +33,7 @@ func TestNotFoundError(t *testing.T) {
 		}
 	}
 
-	var nfe notFoundError
+	var nfe NotFoundError
 	for _, tt := range []struct {
 		n      int
 		err    error

--- a/response_test.go
+++ b/response_test.go
@@ -296,7 +296,7 @@ func TestResponseError(t *testing.T) {
 		},
 		{
 			n:                4,
-			err:              notFoundError("cache sensitive"),
+			err:              NotFoundError("cache sensitive"),
 			cacheSensitive:   true,
 			wantStatusCode:   http.StatusNotFound,
 			wantCacheControl: "public, max-age=60",
@@ -304,14 +304,14 @@ func TestResponseError(t *testing.T) {
 		},
 		{
 			n:                5,
-			err:              notFoundError("not found: bad upstream"),
+			err:              NotFoundError("not found: bad upstream"),
 			wantStatusCode:   http.StatusNotFound,
 			wantCacheControl: "must-revalidate, no-cache, no-store",
 			wantContent:      "not found: bad upstream",
 		},
 		{
 			n:                6,
-			err:              notFoundError("not found: fetch timed out"),
+			err:              NotFoundError("not found: fetch timed out"),
 			wantStatusCode:   http.StatusNotFound,
 			wantCacheControl: "must-revalidate, no-cache, no-store",
 			wantContent:      "not found: fetch timed out",


### PR DESCRIPTION
This PR turns the `fetch` struct into an interface and introduces a `Fetcher` interface.
The use case is to allow the creation of alternative implementations.  For example, at my company, we
fork all public Github repositories so we have more control over their lifecycles, and are able to operate in
an environment without public internet access.  A custom Fetcher allows us to redirect go module requests to
our internal repos.

The existing flow is essentially untouched - but several data structures are made public so that they may be imported.