### PR TITLE
feat(Cacher): support optional `interface{ Size() int64 }` for Content-Length header

### DIFF
--- a/cacher.go
+++ b/cacher.go
@@ -27,8 +27,8 @@ type Cacher interface {
 	//     headers when 1 is implemented. Note that the return value will be
 	//     assumed to have complied with RFC 7232, section 2.3, so it will
 	//     be used directly without further processing.
-	//  5. interface{ Size() int64 }, mainly for the Content-Length
-	//     response header.
+	//  5. interface{ Size() int64 }, mainly for the Content-Length response
+	//     header.
 	Get(ctx context.Context, name string) (io.ReadCloser, error)
 
 	// Put puts a cache for the name with the content.

--- a/cacher.go
+++ b/cacher.go
@@ -16,19 +16,19 @@ type Cacher interface {
 	// The returned [io.ReadCloser] may optionally implement the following
 	// interfaces:
 	//  1. [io.Seeker], mainly for the Range request header.
-	//  2. interface{ LastModified() time.Time }, mainly for the
+	//  2. interface{ Size() int64 }, mainly for the Content-Length response
+	//     header. It takes effect only if 1 is not implemented.
+	//  3. interface{ LastModified() time.Time }, mainly for the
 	//     Last-Modified response header. Also for the If-Unmodified-Since,
 	//     If-Modified-Since, and If-Range request headers when 1 is
 	//     implemented.
-	//  3. interface{ ModTime() time.Time }, same as 2 but with lower
+	//  4. interface{ ModTime() time.Time }, same as 2 but with lower
 	//     priority.
-	//  4. interface{ ETag() string }, mainly for the ETag response header.
+	//  5. interface{ ETag() string }, mainly for the ETag response header.
 	//     Also for the If-Match, If-None-Match, and If-Range request
 	//     headers when 1 is implemented. Note that the return value will be
 	//     assumed to have complied with RFC 7232, section 2.3, so it will
 	//     be used directly without further processing.
-	//  5. interface{ Size() int64 }, mainly for the Content-Length response
-	//     header.
 	Get(ctx context.Context, name string) (io.ReadCloser, error)
 
 	// Put puts a cache for the name with the content.

--- a/cacher.go
+++ b/cacher.go
@@ -27,6 +27,8 @@ type Cacher interface {
 	//     headers when 1 is implemented. Note that the return value will be
 	//     assumed to have complied with RFC 7232, section 2.3, so it will
 	//     be used directly without further processing.
+	//  5. interface{ Size() int64 }, mainly for the Content-Length
+	//     response header.
 	Get(ctx context.Context, name string) (io.ReadCloser, error)
 
 	// Put puts a cache for the name with the content.

--- a/response.go
+++ b/response.go
@@ -91,7 +91,7 @@ func responseSuccess(rw http.ResponseWriter, req *http.Request, content io.Reade
 
 	if sz, ok := content.(interface{ Size() int64 }); ok {
 		if size := sz.Size(); size > 0 {
-			w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
+			rw.Header().Set("Content-Length", strconv.FormatInt(size, 10))
 		}
 	}
 

--- a/response.go
+++ b/response.go
@@ -88,6 +88,12 @@ func responseSuccess(rw http.ResponseWriter, req *http.Request, content io.Reade
 		return
 	}
 
+	if sz, ok := content.(interface{ Size() int64 }); ok {
+		if size := sz.Size(); size != 0 {
+			w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
+		}
+	}
+
 	if !lastModified.IsZero() {
 		rw.Header().Set("Last-Modified", lastModified.UTC().Format(http.TimeFormat))
 	}

--- a/response.go
+++ b/response.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/fs"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -89,7 +90,7 @@ func responseSuccess(rw http.ResponseWriter, req *http.Request, content io.Reade
 	}
 
 	if sz, ok := content.(interface{ Size() int64 }); ok {
-		if size := sz.Size(); size != 0 {
+		if size := sz.Size(); size > 0 {
 			w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
 		}
 	}

--- a/response.go
+++ b/response.go
@@ -90,7 +90,7 @@ func responseSuccess(rw http.ResponseWriter, req *http.Request, content io.Reade
 	}
 
 	if s, ok := content.(interface{ Size() int64 }); ok {
-		if size := sz.Size(); size > 0 {
+		if size := s.Size(); size > 0 {
 			rw.Header().Set("Content-Length", strconv.FormatInt(size, 10))
 		}
 	}

--- a/response.go
+++ b/response.go
@@ -89,7 +89,7 @@ func responseSuccess(rw http.ResponseWriter, req *http.Request, content io.Reade
 		return
 	}
 
-	if sz, ok := content.(interface{ Size() int64 }); ok {
+	if s, ok := content.(interface{ Size() int64 }); ok {
 		if size := sz.Size(); size > 0 {
 			rw.Header().Set("Content-Length", strconv.FormatInt(size, 10))
 		}


### PR DESCRIPTION
If the cached object does not implement `io.ReadSeeker` (which defers processing to `http.ServeContent`), the HTTP response does _not_ include a `Content-Length` header. This PR adds an optional interface that will be converted to the `Content-Length` header if present.