### PR TITLE
fix(GoFetcher): include `latest` query when performing `directList`

### DIFF
--- a/fetcher.go
+++ b/fetcher.go
@@ -324,7 +324,7 @@ func (gf *GoFetcher) proxyList(ctx context.Context, path string, proxy *url.URL)
 // directList lists the available versions for the given module path using the
 // local Go binary.
 func (gf *GoFetcher) directList(ctx context.Context, path string) (versions []string, err error) {
-	output, err := gf.execGo(ctx, "list", "-json", "-m", "-versions", path)
+	output, err := gf.execGo(ctx, "list", "-json", "-m", "-versions", path+"@latest")
 	if err != nil {
 		return
 	}

--- a/fetcher_test.go
+++ b/fetcher_test.go
@@ -618,7 +618,7 @@ func TestGoFetcherDirectList(t *testing.T) {
 		{
 			n:       2,
 			path:    "foobar",
-			wantErr: errors.New(`malformed module path "foobar": missing dot in first path element`),
+			wantErr: errors.New(`foobar@latest: malformed module path "foobar": missing dot in first path element`),
 		},
 	} {
 		gf := &GoFetcher{TempDir: t.TempDir()}


### PR DESCRIPTION
Fix https://github.com/goproxy/goproxy/issues/72
