### PR TITLE
chore: replace `interface{}` with `any`

### DIFF
--- a/fetcher_test.go
+++ b/fetcher_test.go
@@ -1233,8 +1233,8 @@ func (misbehavingDoneContext) Done() <-chan struct{} {
 	close(ch)
 	return ch
 }
-func (misbehavingDoneContext) Err() error                        { return nil }
-func (misbehavingDoneContext) Value(key interface{}) interface{} { return nil }
+func (misbehavingDoneContext) Err() error        { return nil }
+func (misbehavingDoneContext) Value(key any) any { return nil }
 
 func TestGoFetcherExecGo(t *testing.T) {
 	t.Setenv("GOMODCACHE", t.TempDir())

--- a/http.go
+++ b/http.go
@@ -39,7 +39,7 @@ func (notExistError) Is(target error) bool { return target == fs.ErrNotExist }
 
 // notExistErrorf formats according to a format specifier and returns the string
 // as a value that satisfies error that is equivalent to [fs.ErrNotExist].
-func notExistErrorf(format string, v ...interface{}) error {
+func notExistErrorf(format string, v ...any) error {
 	return &notExistError{err: fmt.Errorf(format, v...)}
 }
 


### PR DESCRIPTION
Script used:

```
gofmt -r 'interface{} -> any' -w .
```