### PR TITLE
chore: update release workflow to separate tagging and publishing

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,19 +1,38 @@
 {
 	"$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-	"bump-minor-pre-major": true,
-	"bump-patch-for-minor-pre-major": true,
-	"draft-pull-request": true,
-	"changelog-sections": [
-		{ "type": "feat", "section": "Features" },
-		{ "type": "fix", "section": "Bug Fixes" },
-		{ "type": "refactor", "section": "Code Refactoring"},
-		{ "type": "test", "section": "Tests"},
-		{ "type": "docs", "section": "Documentation"},
-		{ "type": "chore", "section": "Miscellaneous Chores"}
-	],
 	"packages": {
 		".": {
 			"release-type": "go"
 		}
-	}
+	},
+	"bump-minor-pre-major": true,
+	"bump-patch-for-minor-pre-major": true,
+	"changelog-sections": [
+		{
+			"type": "feat",
+			"section": "Features"
+		},
+		{
+			"type": "fix",
+			"section": "Bug Fixes"
+		},
+		{
+			"type": "refactor",
+			"section": "Code Refactoring"
+		},
+		{
+			"type": "test",
+			"section": "Tests"
+		},
+		{
+			"type": "docs",
+			"section": "Documentation"
+		},
+		{
+			"type": "chore",
+			"section": "Miscellaneous Chores"
+		}
+	],
+	"draft": true,
+	"draft-pull-request": true
 }

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -164,4 +164,5 @@ snapshot:
   version_template: '{{trimprefix .Summary "v"}}'
 
 release:
+  use_existing_draft: true
   prerelease: auto


### PR DESCRIPTION
- Configure Release Please to create release drafts.
- Use GoReleaser to inject artifacts and publish the draft.

This streamlines the release process by deferring publication until artifacts are ready.