### PR TITLE
revert: chore: update release workflow to separate tagging and publishing

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -33,6 +33,5 @@
 			"section": "Miscellaneous Chores"
 		}
 	],
-	"draft": true,
 	"draft-pull-request": true
 }

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -164,5 +164,4 @@ snapshot:
   version_template: '{{trimprefix .Summary "v"}}'
 
 release:
-  use_existing_draft: true
   prerelease: auto


### PR DESCRIPTION
This reverts commit 33c5b1e9a3991d6f067f6a98f5190407f31d9e95.