### PR TITLE
Fix: close downloaded files immediately

### DIFF
--- a/goproxy.go
+++ b/goproxy.go
@@ -274,11 +274,9 @@ func (g *Goproxy) serveFetchDownload(rw http.ResponseWriter, req *http.Request, 
 		responseError(rw, req, err, false)
 		return
 	}
-	defer func() {
-		info.Close()
-		mod.Close()
-		zip.Close()
-	}()
+	defer info.Close()
+	defer mod.Close()
+	defer zip.Close()
 
 	targetWithoutExt := strings.TrimSuffix(target, path.Ext(target))
 	for _, cache := range []struct {


### PR DESCRIPTION
This PR fixes a potential resource leak in the `serveFetchDownload` function by ensuring that the `info`, `mod`, and `zip` file handles are closed immediately after they are returned from the `fetcher.Download` function. This prevents file descriptors from being leaked in error paths.

Fixes #138