### PR TITLE
fix(ci): add Docker Buildx setup for GoReleaser `dockers_v2` support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,8 @@ jobs:
           go-version: 1.25.x
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -72,6 +72,8 @@ jobs:
           go-version: 1.25.x
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:


### PR DESCRIPTION
This resolves the "failed to publish artifacts" error in GoReleaser's `dockers_v2` feature by adding the missing `docker/setup-buildx-action` step, which is required for multi-platform Docker image builds.