### PR TITLE
chore(ci): update release workflow to separate tagging and publishing

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -33,5 +33,7 @@
 			"section": "Miscellaneous Chores"
 		}
 	],
+	"draft": true,
+	"force-tag-creation": true,
 	"draft-pull-request": true
 }

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -60,4 +60,5 @@ snapshot:
   version_template: '{{trimprefix .Summary "v"}}'
 
 release:
+  use_existing_draft: true
   prerelease: auto


### PR DESCRIPTION
- Enable `draft` mode for Release Please to create draft releases
- Enable `force-tag-creation` to ensure git tags are created immediately
- Configure GoReleaser to use existing draft via `use_existing_draft`

This re-enables the workflow that was reverted in #126. The previous attempt failed because GitHub does not create git tags for draft releases until they are published. The new `force-tag-creation` option in release-please 17.2.0[^1] solves this by forcing immediate tag creation.

[^1]: https://github.com/googleapis/release-please/releases/tag/v17.2.0