### PR TITLE
refactor(GoFetcher)!: clarify direct fetch concurrency naming

### DIFF
--- a/cmd/goproxy/internal/server_cmd.go
+++ b/cmd/goproxy/internal/server_cmd.go
@@ -43,22 +43,22 @@ conflicts. Misuse of a shared GOMODCACHE may lead to deadlocks.
 
 // serverCmdConfig is the configuration for server command.
 type serverCmdConfig struct {
-	address          string
-	tlsCertFile      string
-	tlsKeyFile       string
-	pathPrefix       string
-	goBin            string
-	maxDirectFetches int
-	proxiedSumDBs    []string
-	cacher           string
-	cacherDir        string
-	s3CacherOpts     s3CacherOptions
-	tempDir          string
-	insecure         bool
-	connectTimeout   time.Duration
-	fetchTimeout     time.Duration
-	shutdownTimeout  time.Duration
-	logFormat        string
+	address                    string
+	tlsCertFile                string
+	tlsKeyFile                 string
+	pathPrefix                 string
+	goBin                      string
+	maxConcurrentDirectFetches int
+	proxiedSumDBs              []string
+	cacher                     string
+	cacherDir                  string
+	s3CacherOpts               s3CacherOptions
+	tempDir                    string
+	insecure                   bool
+	connectTimeout             time.Duration
+	fetchTimeout               time.Duration
+	shutdownTimeout            time.Duration
+	logFormat                  string
 }
 
 // newServerCmdConfig creates a new [serverCmdConfig].
@@ -70,7 +70,7 @@ func newServerCmdConfig(cmd *cobra.Command) *serverCmdConfig {
 	fs.StringVar(&cfg.tlsKeyFile, "tls-key-file", "", "path to the TLS key file")
 	fs.StringVar(&cfg.pathPrefix, "path-prefix", "", "prefix for all request paths")
 	fs.StringVar(&cfg.goBin, "go-bin", "go", "path to the Go binary that is used to execute direct fetches")
-	fs.IntVar(&cfg.maxDirectFetches, "max-direct-fetches", 0, "maximum number (0 means no limit) of concurrent direct fetches")
+	fs.IntVar(&cfg.maxConcurrentDirectFetches, "max-concurrent-direct-fetches", 0, "maximum number (0 means no limit) of concurrent direct fetches")
 	fs.StringSliceVar(&cfg.proxiedSumDBs, "proxied-sumdbs", nil, "list of proxied checksum databases")
 	fs.StringVar(&cfg.cacher, "cacher", "dir", "cacher to use (valid values: dir, s3)")
 	fs.StringVar(&cfg.cacherDir, "cacher-dir", "caches", "directory for the dir cacher")
@@ -99,10 +99,10 @@ func runServerCmd(cmd *cobra.Command, args []string, cfg *serverCmdConfig) error
 	transport.RegisterProtocol("file", http.NewFileTransport(httpDirFS{}))
 	g := &goproxy.Goproxy{
 		Fetcher: &goproxy.GoFetcher{
-			GoBin:            cfg.goBin,
-			MaxDirectFetches: cfg.maxDirectFetches,
-			TempDir:          cfg.tempDir,
-			Transport:        transport,
+			GoBin:                      cfg.goBin,
+			MaxConcurrentDirectFetches: cfg.maxConcurrentDirectFetches,
+			TempDir:                    cfg.tempDir,
+			Transport:                  transport,
 		},
 		ProxiedSumDBs: cfg.proxiedSumDBs,
 		TempDir:       cfg.tempDir,

--- a/fetcher.go
+++ b/fetcher.go
@@ -107,10 +107,11 @@ type GoFetcher struct {
 	// If GoBin is empty, "go" is used.
 	GoBin string
 
-	// MaxDirectFetches is the maximum number of concurrent direct fetches.
+	// MaxConcurrentDirectFetches is the maximum number of concurrent direct
+	// fetches.
 	//
-	// If MaxDirectFetches is zero, there is no limit.
-	MaxDirectFetches int
+	// If MaxConcurrentDirectFetches is zero, there is no limit.
+	MaxConcurrentDirectFetches int
 
 	// TempDir is the directory for storing temporary files.
 	//
@@ -182,8 +183,8 @@ func (gf *GoFetcher) init() {
 		"GOPRIVATE=",
 	)
 
-	if gf.MaxDirectFetches > 0 {
-		gf.directFetchWorkerPool = make(chan struct{}, gf.MaxDirectFetches)
+	if gf.MaxConcurrentDirectFetches > 0 {
+		gf.directFetchWorkerPool = make(chan struct{}, gf.MaxConcurrentDirectFetches)
 	}
 
 	gf.httpClient = &http.Client{Transport: gf.Transport}

--- a/fetcher_test.go
+++ b/fetcher_test.go
@@ -76,10 +76,10 @@ func TestGoFetcherInit(t *testing.T) {
 	} {
 		t.Run(strconv.Itoa(tt.n), func(t *testing.T) {
 			gf := &GoFetcher{
-				Env:              tt.env,
-				MaxDirectFetches: 10,
-				TempDir:          t.TempDir(),
-				Transport:        http.DefaultTransport,
+				Env:                        tt.env,
+				MaxConcurrentDirectFetches: 10,
+				TempDir:                    t.TempDir(),
+				Transport:                  http.DefaultTransport,
 			}
 			gf.initOnce.Do(gf.init)
 			if tt.wantInitErr != nil {
@@ -1301,9 +1301,9 @@ func TestGoFetcherExecGo(t *testing.T) {
 			}
 
 			gf := &GoFetcher{
-				GoBin:            tt.goBin,
-				MaxDirectFetches: 1,
-				TempDir:          tt.tempDir,
+				GoBin:                      tt.goBin,
+				MaxConcurrentDirectFetches: 1,
+				TempDir:                    tt.tempDir,
 			}
 			gf.initOnce.Do(gf.init)
 			if gf.initErr != nil {


### PR DESCRIPTION
Rename `MaxDirectFetches` to `MaxConcurrentDirectFetches` and `--max-direct-fetches` to `--max-concurrent-direct-fetches` so the configuration matches the semaphore limit used by direct fetches.

The previous name read like a cap on total fetch count, but the implementation only limits concurrent direct `go` commands.