### PR TITLE
fix: close resources on error paths

### DIFF
--- a/cmd/goproxy/internal/s3_cacher.go
+++ b/cmd/goproxy/internal/s3_cacher.go
@@ -69,6 +69,7 @@ func (s3c *s3Cacher) Get(ctx context.Context, name string) (io.ReadCloser, error
 	}
 	oi, err := o.Stat()
 	if err != nil {
+		o.Close()
 		if minio.ToErrorResponse(err).StatusCode == http.StatusNotFound {
 			return nil, fs.ErrNotExist
 		}

--- a/goproxy_test.go
+++ b/goproxy_test.go
@@ -1422,6 +1422,7 @@ func makeTempFile(t *testing.T, content []byte) (tempFile string, err error) {
 		return "", err
 	}
 	if _, err := f.Write(content); err != nil {
+		f.Close()
 		return "", err
 	}
 	if err := f.Close(); err != nil {


### PR DESCRIPTION
- Close the S3 object when statting a cache entry fails so callers do not lose ownership of an open object
- Close temp files in the test helper when writing fails